### PR TITLE
feat(security): 添加Helmet中間件以增強API安全頭部配置

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "express-validator": "^7.2.1",
-        "firebase": "^11.6.0"
+        "firebase": "^11.6.0",
+        "helmet": "^8.1.0"
       },
       "devDependencies": {
         "nodemon": "^3.1.9"
@@ -1543,6 +1544,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/http-errors": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "express-validator": "^7.2.1",
-    "firebase": "^11.6.0"
+    "firebase": "^11.6.0",
+    "helmet": "^8.1.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.9"

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import cors from 'cors';
 import dotenv from 'dotenv';
+import helmet from 'helmet';
 import { recommendationRoutes } from './routes/recommendation.js';
 import { errorHandler, notFoundHandler } from './middleware/errorHandler.js';
 import { handleJsonErrors } from './middleware/validator.js';
@@ -15,6 +16,37 @@ const PORT = process.env.PORT || 3000;
 // 基本中間件設置
 app.use(express.json({ limit: '1mb' }));
 app.use(handleJsonErrors); // JSON解析錯誤處理
+
+// 安全頭部配置 - 使用helmet中間件
+app.use(helmet());
+// 自定義Content-Security-Policy
+app.use(
+  helmet.contentSecurityPolicy({
+    directives: {
+      defaultSrc: ["'self'"],
+      scriptSrc: ["'self'", "'unsafe-inline'"],
+      styleSrc: ["'self'", "'unsafe-inline'"],
+      imgSrc: ["'self'", "data:"],
+      connectSrc: ["'self'", process.env.NODE_ENV === 'production' ? '' : 'http://localhost:*'],
+      fontSrc: ["'self'"],
+      objectSrc: ["'none'"],
+      mediaSrc: ["'self'"],
+      frameSrc: ["'none'"],
+    },
+  })
+);
+// 設置X-XSS-Protection
+app.use(helmet.xssFilter());
+// 設置X-Content-Type-Options
+app.use(helmet.noSniff());
+// 設置Strict-Transport-Security
+app.use(
+  helmet.hsts({
+    maxAge: 15552000, // 180天
+    includeSubDomains: true,
+    preload: true,
+  })
+);
 
 // 設置 CORS 中間件 - 允許跨域請求
 const allowedOrigins = process.env.ALLOWED_ORIGINS 


### PR DESCRIPTION
## feat(security): 添加Helmet中間件以增強API安全頭部配置

實作了安全頭部配置，利用Helmet中間件增強應用程式的Web安全性。此PR主要解決了建議文件中關於HTTP安全頭部的要求。

### 修改內容:

- 安裝helmet套件至生產依賴
- 配置以下安全HTTP標頭:
  - Content-Security-Policy - 嚴格限制資源來源，僅允許必要的連接
  - X-XSS-Protection - 啟用瀏覽器內建的XSS防護
  - X-Content-Type-Options - 防止MIME類型探測攻擊
  - Strict-Transport-Security - 強制使用HTTPS連線（有效期180天）

